### PR TITLE
🚨 FluentValidation: Fix incorrect nullability annotation (nullable reference types)

### DIFF
--- a/src/OptionalValues.FluentValidation/OptionalRuleExtensions.cs
+++ b/src/OptionalValues.FluentValidation/OptionalRuleExtensions.cs
@@ -23,7 +23,7 @@ public static class OptionalRuleExtensions
     /// </exception>
     public static void OptionalRuleFor<T, TProperty>(
         this AbstractValidator<T> validator,
-        Expression<Func<T, OptionalValue<TProperty?>>> propertySelector,
+        Expression<Func<T, OptionalValue<TProperty>>> propertySelector,
         Func<IRuleBuilderInitial<T, TProperty>, IRuleBuilderOptions<T, TProperty>> configure)
     {
         ArgumentNullException.ThrowIfNull(validator);
@@ -53,13 +53,13 @@ public static class OptionalRuleExtensions
         });
     }
 
-    private readonly struct WhenIsSpecified<T, TProperty>(Expression<Func<T, OptionalValue<TProperty?>>> propertySelector)
+    private readonly struct WhenIsSpecified<T, TProperty>(Expression<Func<T, OptionalValue<TProperty>>> propertySelector)
     {
-        private readonly Func<T, OptionalValue<TProperty?>> _propertySelectorFunc = propertySelector.Compile();
+        private readonly Func<T, OptionalValue<TProperty>> _propertySelectorFunc = propertySelector.Compile();
 
         public bool Check(T instance)
         {
-            OptionalValue<TProperty?> value = _propertySelectorFunc(instance);
+            OptionalValue<TProperty> value = _propertySelectorFunc(instance);
             return value.IsSpecified;
         }
     }

--- a/src/OptionalValues.FluentValidation/PublicAPI.Shipped.txt
+++ b/src/OptionalValues.FluentValidation/PublicAPI.Shipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
 OptionalValues.FluentValidation.OptionalRuleExtensions
-static OptionalValues.FluentValidation.OptionalRuleExtensions.OptionalRuleFor<T, TProperty>(this FluentValidation.AbstractValidator<T>! validator, System.Linq.Expressions.Expression<System.Func<T, OptionalValues.OptionalValue<TProperty?>>!>! propertySelector, System.Func<FluentValidation.IRuleBuilderInitial<T, TProperty>!, FluentValidation.IRuleBuilderOptions<T, TProperty>!>! configure) -> void
+static OptionalValues.FluentValidation.OptionalRuleExtensions.OptionalRuleFor<T, TProperty>(this FluentValidation.AbstractValidator<T>! validator, System.Linq.Expressions.Expression<System.Func<T, OptionalValues.OptionalValue<TProperty>>!>! propertySelector, System.Func<FluentValidation.IRuleBuilderInitial<T, TProperty>!, FluentValidation.IRuleBuilderOptions<T, TProperty>!>! configure) -> void

--- a/test/OptionalValues.FluentValidation.Tests/OptionalRuleExtensionsTest.cs
+++ b/test/OptionalValues.FluentValidation.Tests/OptionalRuleExtensionsTest.cs
@@ -61,6 +61,7 @@ public class OptionalRuleExtensionsTest
     public class TestData
     {
         public OptionalValue<string?> FirstName { get; set; }
+        public OptionalValue<string> LastName { get; set; }
         public OptionalValue<int> Age { get; set; }
     }
 
@@ -71,6 +72,9 @@ public class OptionalRuleExtensionsTest
             this.OptionalRuleFor(x => x.FirstName, x => x
                 .NotEmpty()
                 .MinimumLength(3));
+
+            this.OptionalRuleFor(x => x.LastName, x => x
+                .NotEmpty());
 
             this.OptionalRuleFor(x => x.Age, x => x
                 .GreaterThan(18));


### PR DESCRIPTION
This fixes warnings when the OptionalRuleFor was applied to a not nullable OptionalValue. For example `OptionalValue<string>`