### PR TITLE
✅ Add tests around records the required keyword

### DIFF
--- a/test/OptionalValues.Tests/Json/RecordTest.cs
+++ b/test/OptionalValues.Tests/Json/RecordTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json;
+
+using Shouldly;
+
+namespace OptionalValues.Tests.Json;
+
+public class RecordTest
+{
+    private static readonly JsonSerializerOptions Options = new JsonSerializerOptions()
+        .AddOptionalValueSupport();
+
+    private record RecordModel(OptionalValue<string> Name);
+
+    [Fact]
+    public void CanSerializeEmpty()
+    {
+        var model = new RecordModel(default);
+        var result = JsonSerializer.Serialize(model, Options);
+
+        Assert.Equal("{}", result);
+    }
+
+    [Fact]
+    public void CanDeserializeEmpty()
+    {
+        var json = "{}";
+
+        RecordModel? result = JsonSerializer.Deserialize<RecordModel>(json, Options);
+        Assert.NotNull(result);
+        result.Name.IsSpecified.ShouldBeFalse();
+    }
+}

--- a/test/OptionalValues.Tests/Json/RequiredKeywordTest.cs
+++ b/test/OptionalValues.Tests/Json/RequiredKeywordTest.cs
@@ -9,7 +9,12 @@ public class RequiredKeywordTest
     private static readonly JsonSerializerOptions Options = new JsonSerializerOptions()
         .AddOptionalValueSupport();
 
-    public class RequiredKeywordModel
+    public class RequiredKeywordClassModel
+    {
+        public required OptionalValue<string> NotRequired { get; init; }
+    }
+
+    public record RequiredKeywordRecordModel
     {
         public required OptionalValue<string> NotRequired { get; init; }
     }
@@ -24,10 +29,12 @@ public class RequiredKeywordTest
     {
         var json = "{}";
 
-        RequiredKeywordModel? requiredKeywordModel = JsonSerializer.Deserialize<RequiredKeywordModel>(json, Options);
+        RequiredKeywordClassModel? requiredKeywordClassModel = JsonSerializer.Deserialize<RequiredKeywordClassModel>(json, Options);
+        RequiredKeywordRecordModel? requiredKeywordRecordModel = JsonSerializer.Deserialize<RequiredKeywordRecordModel>(json, Options);
         Func<ReferenceModel?> actReference = () => JsonSerializer.Deserialize<ReferenceModel>(json, Options);
 
-        requiredKeywordModel!.NotRequired.IsSpecified.ShouldBeFalse();
+        requiredKeywordClassModel!.NotRequired.IsSpecified.ShouldBeFalse();
+        requiredKeywordRecordModel!.NotRequired.IsSpecified.ShouldBeFalse();
         actReference.ShouldThrow<JsonException>();
     }
 }


### PR DESCRIPTION
The tests verify that records with properties which are marked as `required` can be omitted from the json when deserializing.

That is, deserializing `{}` to the below model works, and deserializes the `NotRequired` property as `Unspecified`.
```cs
public record RequiredKeywordRecordModel
{
    public required OptionalValue<string> NotRequired { get; init; }
}
```

Verifies https://github.com/desjoerd/OptionalValues/issues/6
Related issue https://github.com/dotnet/runtime/issues/110733